### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/product-analytics.yml
+++ b/.github/workflows/product-analytics.yml
@@ -1,4 +1,6 @@
 name: Product Analytics
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/shrwnsan/beacon-delivery-compass/security/code-scanning/1](https://github.com/shrwnsan/beacon-delivery-compass/security/code-scanning/1)

The best way to fix the reported issue is to add a `permissions` key specifying minimal permissions required by the workflow. As none of the shown steps require write access to contents or other resources, adding `permissions: contents: read` at the workflow root is sufficient in this case. This ensures all jobs in the workflow, including the shown `generate-report` job, will operate with only read access to the repository contents, reducing the risk inherent with unused write permissions. The change should be made at the top level of the workflow, right after the `name` key and before `on`, to apply to all jobs in the workflow. No new methods, imports, or other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
