### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/shrwnsan/beacon-delivery-compass/security/code-scanning/2](https://github.com/shrwnsan/beacon-delivery-compass/security/code-scanning/2)

To follow the principle of least privilege and prevent over-granting access, add a `permissions` block with the minimum required permission. This block should be placed at the top-level of the workflow (recommended), which automatically applies to all jobs unless overridden. For most CI pipelines, especially where jobs merely build, test, and report coverage, `contents: read` suffices. If some steps later require more permissions, this can be incrementally added at the job or workflow level as needed.

**How to fix:**  
- Add a new root-level key `permissions:` with `contents: read` near the top of `.github/workflows/ci.yml` (e.g., after `name:` but before `on:`).

**Required changes:**  
- Insert the following at the top-level:
    ```yaml
    permissions:
      contents: read
    ```
- No other changes or imports needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
